### PR TITLE
updated android-guide.md for linking command bug

### DIFF
--- a/docs/android-guide.md
+++ b/docs/android-guide.md
@@ -22,7 +22,7 @@ Please note that this package requires android gradle plugin of version >= 3, wh
 
 in RN >= 0.60 you should not need to do anything thanks to [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md)
 
-in RN < 0.60 run `react-native link @react-native-community/google-signin`
+in RN < 0.60 run `react-native link react-native-google-signin`
 
 2 . Update `android/build.gradle` with
 


### PR DESCRIPTION
In the main [readme](https://github.com/react-native-community/react-native-google-signin/blob/master/README.md) file It was said that 
> For RN <= 0.59 use version 2 installed from react-native-google-signin
> yarn add react-native-google-signin

now in this document its saying to link a package which was never installed
> in RN < 0.60 run react-native link @react-native-community/google-signin

fixed it to `react-native link react-native-google-signin`